### PR TITLE
refactor(components): using matrix instead of multiple groups for hearts and stars

### DIFF
--- a/src/components/Emoji.tsx
+++ b/src/components/Emoji.tsx
@@ -1,5 +1,5 @@
-import React, { memo, useCallback, useEffect } from 'react';
-import { runSpring, SkFont, Text, useValue } from '@shopify/react-native-skia';
+import React, { memo } from 'react';
+import { SkFont, Text, useSpring } from '@shopify/react-native-skia';
 import { singleItemFadeSpeed } from '../constants/speed';
 
 export interface EmojiProps {
@@ -12,16 +12,10 @@ export interface EmojiProps {
 
 export const Emoji = memo(
   ({ x = 0, y = 0, autoHide = true, emoji = '🎉', font }: EmojiProps) => {
-    const opacity = useValue(1);
-
-    const changeOpacity = useCallback(
-      () => runSpring(opacity, 0, singleItemFadeSpeed),
-      [opacity]
+    const opacity = useSpring(
+      { to: autoHide ? 0 : 1, from: 1 },
+      singleItemFadeSpeed
     );
-
-    useEffect(() => {
-      autoHide && changeOpacity();
-    }, [autoHide, changeOpacity]);
 
     if (!font) return null;
 

--- a/src/components/Heart.tsx
+++ b/src/components/Heart.tsx
@@ -1,5 +1,9 @@
-import React, { memo, useCallback, useEffect } from 'react';
-import { Group, Path, runSpring, useValue } from '@shopify/react-native-skia';
+import React, { memo, useMemo } from 'react';
+import {
+  Path,
+  processTransform2d,
+  useSpring,
+} from '@shopify/react-native-skia';
 import { baseColors } from '../constants/theming';
 import { singleItemFadeSpeed } from '../constants/speed';
 
@@ -12,30 +16,28 @@ export interface HeartProps {
 
 export const Heart = memo(
   ({ x, y, autoplay = true, color = baseColors.red }: HeartProps) => {
-    const opacity = useValue(1);
-
-    const changeOpacity = useCallback(
-      () => runSpring(opacity, 0, singleItemFadeSpeed),
-      [opacity]
+    const opacity = useSpring(
+      { to: autoplay ? 0 : 1, from: 1 },
+      singleItemFadeSpeed
     );
 
-    useEffect(() => {
-      autoplay && changeOpacity();
-    }, [autoplay, changeOpacity]);
+    const matrix = useMemo(
+      () =>
+        processTransform2d([
+          { translateX: x },
+          { translateY: y },
+          { scale: 0.05 },
+        ]),
+      [x, y]
+    );
 
     return (
-      // @TODO: this can be optimised by using a matrix instead of multiple transforms
-      <Group transform={[{ translateY: y }]}>
-        <Group transform={[{ translateX: x }]}>
-          <Group transform={[{ scale: 0.05 }]}>
-            <Path
-              path="m263.42 235.15c-66.24 0-120 53.76-120 120 0 134.76 135.93 170.09 228.56 303.31 87.574-132.4 228.56-172.86 228.56-303.31 0-66.24-53.76-120-120-120-48.048 0-89.402 28.37-108.56 69.188-19.161-40.817-60.514-69.188-108.56-69.188z"
-              color={color}
-              opacity={opacity}
-            />
-          </Group>
-        </Group>
-      </Group>
+      <Path
+        path="m263.42 235.15c-66.24 0-120 53.76-120 120 0 134.76 135.93 170.09 228.56 303.31 87.574-132.4 228.56-172.86 228.56-303.31 0-66.24-53.76-120-120-120-48.048 0-89.402 28.37-108.56 69.188-19.161-40.817-60.514-69.188-108.56-69.188z"
+        color={color}
+        opacity={opacity}
+        matrix={matrix}
+      />
     );
   }
 );

--- a/src/components/Star.tsx
+++ b/src/components/Star.tsx
@@ -1,5 +1,9 @@
-import React, { memo, useCallback, useEffect } from 'react';
-import { Group, Path, runSpring, useValue } from '@shopify/react-native-skia';
+import React, { memo, useMemo } from 'react';
+import {
+  Path,
+  processTransform2d,
+  useSpring,
+} from '@shopify/react-native-skia';
 import { baseColors } from '../constants/theming';
 import { singleItemFadeSpeed } from '../constants/speed';
 
@@ -12,30 +16,28 @@ export interface StarProps {
 
 export const Star = memo(
   ({ x, y, autoplay = true, color = baseColors.yellow }: StarProps) => {
-    const opacity = useValue(1);
-
-    const changeOpacity = useCallback(
-      () => runSpring(opacity, 0, singleItemFadeSpeed),
-      [opacity]
+    const opacity = useSpring(
+      { to: autoplay ? 0 : 1, from: 1 },
+      singleItemFadeSpeed
     );
 
-    useEffect(() => {
-      autoplay && changeOpacity();
-    }, [autoplay, changeOpacity]);
+    const matrix = useMemo(
+      () =>
+        processTransform2d([
+          { translateX: x },
+          { translateY: y },
+          { scale: 0.1 },
+        ]),
+      [x, y]
+    );
 
     return (
-      // @TODO: this can be optimised by using a matrix instead of multiple transforms
-      <Group transform={[{ translateY: y }]}>
-        <Group transform={[{ translateX: x }]}>
-          <Group transform={[{ scale: 0.1 }]}>
-            <Path
-              path="M 128 0 L 168 80 L 256 93 L 192 155 L 207 244 L 128 202 L 49 244 L 64 155 L 0 93 L 88 80 L 128 0 Z"
-              color={color}
-              opacity={opacity}
-            />
-          </Group>
-        </Group>
-      </Group>
+      <Path
+        path="M 128 0 L 168 80 L 256 93 L 192 155 L 207 244 L 128 202 L 49 244 L 64 155 L 0 93 L 88 80 L 128 0 Z"
+        color={color}
+        opacity={opacity}
+        matrix={matrix}
+      />
     );
   }
 );


### PR DESCRIPTION
- Removing unnecessary groups using a single matrix
- Using `useSpring` hook to execute the fade out in a cleaner way