### PR TITLE
feat(poppers): custom popper elements

### DIFF
--- a/example/src/components/Examples.tsx
+++ b/example/src/components/Examples.tsx
@@ -7,7 +7,7 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Canvas, useFont } from '@shopify/react-native-skia';
+import { Canvas, Circle, useFont } from '@shopify/react-native-skia';
 import {
   Fireworks,
   FiestaThemes,
@@ -23,6 +23,7 @@ import {
   PopperDirection,
   Confettis,
   Confetti,
+  CustomPoppers,
 } from 'react-native-fiesta';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import Header from './Header';
@@ -216,6 +217,26 @@ export function Examples() {
 
           <Text style={[styles.pressableText, styles.textColor]}>
             Confettis
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() =>
+            onChangeComponent(
+              <CustomPoppers
+                theme={selectedTheme}
+                key={dynamicKey}
+                children={<Circle r={100} color="lightblue" />}
+              />
+            )
+          }
+          style={styles.pressable}
+        >
+          <Canvas style={styles.canvas}>
+            <Circle r={10} color="lightblue" />
+          </Canvas>
+          <Text style={[styles.pressableText, styles.textColor]}>
+            Custom Popper Element
           </Text>
         </TouchableOpacity>
       </ScrollView>

--- a/src/components/Confetti.tsx
+++ b/src/components/Confetti.tsx
@@ -7,8 +7,11 @@ import {
   withTiming,
 } from 'react-native-reanimated';
 import { screenHeight } from '../constants/dimensions';
-import { degreesToRadians, randomIntFromInterval } from '../utils/confettis';
-import { DEFAULT_ANIMATION_DURATION } from './Confettis';
+import {
+  degreesToRadians,
+  randomIntFromInterval,
+  DEFAULT_ANIMATION_DURATION,
+} from '../utils/confettis';
 
 export interface ConfettiProps {
   initialPosition?: { x: number; y: number };

--- a/src/components/Confettis.tsx
+++ b/src/components/Confettis.tsx
@@ -4,11 +4,11 @@ import { Canvas } from '@shopify/react-native-skia';
 import { FiestaThemes } from '../constants/theming';
 import { colorsFromTheme } from '../utils/colors';
 import { generateRandomCoordinates } from '../utils/fireworks';
+import { DEFAULT_ANIMATION_DURATION } from '../utils/confettis';
 import { screenHeight } from '../constants/dimensions';
 import { Confetti, type ConfettiProps } from './Confetti';
 
 const optimalNumberOfConfettis = 30;
-export const DEFAULT_ANIMATION_DURATION = 6000;
 
 export interface ConfettisProps
   extends Pick<ConfettiProps, 'size' | 'duration'> {

--- a/src/components/CustomPopper.tsx
+++ b/src/components/CustomPopper.tsx
@@ -1,0 +1,40 @@
+import React, { memo, useEffect, useMemo } from 'react';
+import { Group, processTransform2d } from '@shopify/react-native-skia';
+import { useSharedValue, withSpring } from 'react-native-reanimated';
+import { singleItemFadeSpeed } from '../constants/speed';
+
+// @TODO: this props seem to be the same for all components
+// maybe when this replaces the custom poppers, we can move this to a shared file
+export interface CustomPopperProps {
+  x?: number;
+  y?: number;
+  autoPlay?: boolean;
+  color?: string;
+  children: React.ReactNode;
+}
+
+export const CustomPopper = memo(
+  ({ x = 0, y = 0, autoPlay = true, color, children }: CustomPopperProps) => {
+    const opacity = useSharedValue(1);
+
+    const matrix = useMemo(
+      () =>
+        processTransform2d([
+          { translateX: x },
+          { translateY: y },
+          { scale: 0.05 },
+        ]),
+      [x, y]
+    );
+
+    useEffect(() => {
+      opacity.value = withSpring(autoPlay ? 0 : 1, singleItemFadeSpeed);
+    }, [autoPlay, opacity]);
+
+    return (
+      <Group matrix={matrix} opacity={opacity} color={color}>
+        {children}
+      </Group>
+    );
+  }
+);

--- a/src/components/CustomPoppers.tsx
+++ b/src/components/CustomPoppers.tsx
@@ -1,0 +1,32 @@
+import React, { forwardRef } from 'react';
+import { CustomPopper } from './CustomPopper';
+import {
+  Popper,
+  type PopperHandler,
+  type PopperProps,
+  type PopperRef,
+} from './Popper';
+
+export interface CustomPoppersProps extends Omit<PopperProps, 'renderItem'> {
+  children: React.ReactNode;
+}
+
+export const CustomPoppers = forwardRef<PopperHandler, CustomPoppersProps>(
+  (props: CustomPoppersProps, ref?: PopperRef) => (
+    <Popper
+      renderItem={({ x, y, colors }, index) => (
+        <CustomPopper
+          key={index}
+          x={x}
+          y={y}
+          color={colors[index]}
+          autoPlay={false}
+        >
+          {props.children}
+        </CustomPopper>
+      )}
+      {...props}
+      ref={ref}
+    />
+  )
+);

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -12,3 +12,5 @@ export * from './Emoji';
 export * from './Popper';
 export * from './Confettis';
 export * from './Confetti';
+export * from './CustomPopper';
+export * from './CustomPoppers';

--- a/src/utils/confettis.ts
+++ b/src/utils/confettis.ts
@@ -7,3 +7,5 @@ export function randomIntFromInterval(min: number, max: number): number {
   // min and max included
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
+
+export const DEFAULT_ANIMATION_DURATION = 6000;

--- a/src/utils/fireworks.ts
+++ b/src/utils/fireworks.ts
@@ -1,5 +1,10 @@
 import { screenWidth, screenHeight } from '../constants/dimensions';
 
+interface Coordinates {
+  x: number;
+  y: number;
+}
+
 export function fromRadians(angle: number) {
   return angle * (180.0 / Math.PI);
 }
@@ -8,9 +13,9 @@ export function generateRandomCoordinates(
   numElements: number,
   specificHeight?: number,
   specificWidth?: number
-): Array<{ x: number; y: number }> {
+): Array<Coordinates> {
   // Create an array to store the generated coordinates
-  const coordinates: Array<{ x: number; y: number }> = [];
+  const coordinates: Array<Coordinates> = [];
 
   // Generate random x,y coordinates until we have the desired number of elements
   while (coordinates.length < numElements) {


### PR DESCRIPTION
Exposing the `Popper` component in a more customisable way allows passing any children as a custom element. This makes the library more flexible as you are not limited to using the custom built-in animations but you can pass your own.