### PR TITLE
feat(popper): allowing custom position and fading spring configs

### DIFF
--- a/docs/docs/components/popper.mdx
+++ b/docs/docs/components/popper.mdx
@@ -1,0 +1,56 @@
+---
+id: popper
+title: Popper
+sidebar_label: Popper
+slug: /components/popper
+---
+
+A popper component that allows composing a set of elements that are thrown across the screen.
+
+- [Simple Popper](#simple-popper)
+
+### Simple Popper
+
+You can define a custom Skia element and render it within the `Popper`.
+
+```tsx
+import { StyleSheet } from 'react-native';
+import { Canvas, Circle } from '@shopify/react-native-skia';
+import { Popper, PopperDirection } from 'react-native-fiesta';
+
+function App() {
+  return (
+    <Canvas style={styles.canvas}>
+      <Popper
+          direction={PopperDirection.Ascending}
+          spacing={10}
+          renderItem={({ x, y, colors }, index) => (
+            <Circle
+              key={`circle-${index}`}
+              cx={x}
+              cy={y}
+              r={10}
+              color={colors[index]}
+            />
+          )}
+          positionSpringConfig={{
+            stiffness: 100,
+            damping: 100,
+            mass: 11000,
+          }}
+          fadeSpringConfig={{
+            stiffness: 1,
+            damping: 1,
+            mass: 1000,
+          }}
+        />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  canvas: {
+    flex: 1,
+  },
+});
+```

--- a/example/src/components/Examples.tsx
+++ b/example/src/components/Examples.tsx
@@ -102,6 +102,16 @@ export function Examples() {
               animation: FiestaAnimations.Hearts,
               theme: selectedTheme,
               direction: PopperDirection.Ascending,
+              positionSpringConfig: {
+                stiffness: 100,
+                damping: 100,
+                mass: 11000,
+              },
+              fadeSpringConfig: {
+                stiffness: 1,
+                damping: 1,
+                mass: 1000,
+              },
             })
           }
           style={styles.pressable}

--- a/example/src/components/Examples.tsx
+++ b/example/src/components/Examples.tsx
@@ -7,7 +7,7 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { Canvas, useFont } from '@shopify/react-native-skia';
+import { Canvas, Circle, useFont } from '@shopify/react-native-skia';
 import {
   Fireworks,
   FiestaThemes,
@@ -23,6 +23,7 @@ import {
   PopperDirection,
   Confettis,
   Confetti,
+  Popper,
 } from 'react-native-fiesta';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import Header from './Header';
@@ -216,6 +217,47 @@ export function Examples() {
 
           <Text style={[styles.pressableText, styles.textColor]}>
             Confettis
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={() =>
+            onChangeComponent(
+              <Popper
+                direction={PopperDirection.Ascending}
+                theme={selectedTheme}
+                key={dynamicKey}
+                spacing={10}
+                renderItem={({ x, y, colors }, index) => (
+                  <Circle
+                    key={`circle-${index}`}
+                    cx={x}
+                    cy={y}
+                    r={10}
+                    color={colors[index]}
+                  />
+                )}
+                positionSpringConfig={{
+                  stiffness: 100,
+                  damping: 100,
+                  mass: 11000,
+                }}
+                fadeSpringConfig={{
+                  stiffness: 1,
+                  damping: 1,
+                  mass: 1000,
+                }}
+              />
+            )
+          }
+          style={styles.pressable}
+        >
+          <Canvas style={styles.canvas}>
+            <Circle cx={10} cy={10} r={20} color="rgba(255, 0, 255, 0.4)" />
+          </Canvas>
+
+          <Text style={[styles.pressableText, styles.textColor]}>
+            Custom elements using Popper
           </Text>
         </TouchableOpacity>
       </ScrollView>

--- a/src/components/Confetti.tsx
+++ b/src/components/Confetti.tsx
@@ -7,8 +7,11 @@ import {
   withTiming,
 } from 'react-native-reanimated';
 import { screenHeight } from '../constants/dimensions';
-import { degreesToRadians, randomIntFromInterval } from '../utils/confettis';
-import { DEFAULT_ANIMATION_DURATION } from './Confettis';
+import {
+  degreesToRadians,
+  randomIntFromInterval,
+  DEFAULT_ANIMATION_DURATION,
+} from '../utils/confettis';
 
 export interface ConfettiProps {
   initialPosition?: { x: number; y: number };

--- a/src/components/Confettis.tsx
+++ b/src/components/Confettis.tsx
@@ -6,9 +6,9 @@ import { colorsFromTheme } from '../utils/colors';
 import { generateRandomCoordinates } from '../utils/fireworks';
 import { screenHeight } from '../constants/dimensions';
 import { Confetti, type ConfettiProps } from './Confetti';
+import { DEFAULT_ANIMATION_DURATION } from '../utils/confettis';
 
 const optimalNumberOfConfettis = 30;
-export const DEFAULT_ANIMATION_DURATION = 6000;
 
 export interface ConfettisProps
   extends Pick<ConfettiProps, 'size' | 'duration'> {

--- a/src/components/Popper.tsx
+++ b/src/components/Popper.tsx
@@ -7,6 +7,7 @@ import React, {
   useMemo,
   type ForwardedRef,
   useState,
+  useRef,
 } from 'react';
 import { StyleSheet } from 'react-native';
 import { Canvas, Group } from '@shopify/react-native-skia';
@@ -85,32 +86,23 @@ export const Popper = memo(
       }: PopperProps,
       ref: PopperRef
     ) => {
-      // properties that might be controlled are also defined in the state
+      // properties that might be controlled are also defined as states and refs
       const [controlledTheme, setControlledTheme] = useState<string[]>(theme);
-      const [controlledDirection, setControlledDirection] =
-        useState<PopperDirection>(direction);
-      const [
-        controlledPositionSpringConfig,
-        setControlledPositionSpringConfig,
-      ] = useState<SpringConfig>(positionSpringConfig);
-      const [controlledFadeSpringConfig, setControlledFadeSpringConfig] =
-        useState<SpringConfig>(fadeSpringConfig);
+      const controlledDirection = useRef<PopperDirection>(direction);
+      const controlledPositionSpringConfig =
+        useRef<SpringConfig>(positionSpringConfig);
+      const controlledFadeSpringConfig = useRef<SpringConfig>(fadeSpringConfig);
 
       const [displayCanvas, setDisplayCanvas] = useState<boolean>(autoPlay);
-      const initialPosition = useMemo(
-        () =>
-          controlledDirection === PopperDirection.Ascending
-            ? screenHeight
-            : -screenHeight / 2,
-        [controlledDirection]
-      );
-      const finalPosition = useMemo(
-        () =>
-          controlledDirection === PopperDirection.Ascending
-            ? -screenHeight
-            : screenHeight,
-        [controlledDirection]
-      );
+
+      const initialPosition =
+        controlledDirection.current === PopperDirection.Ascending
+          ? screenHeight
+          : -screenHeight / 2;
+      const finalPosition =
+        controlledDirection.current === PopperDirection.Ascending
+          ? -screenHeight
+          : screenHeight;
 
       const optimalNumberOfItems = useMemo(
         () => Math.floor(screenWidth / spacing),
@@ -137,7 +129,7 @@ export const Popper = memo(
       const changeItemPosition = useCallback(() => {
         containerYPosition.value = withSpring(
           finalPosition,
-          controlledPositionSpringConfig,
+          controlledPositionSpringConfig.current,
           (finished) => {
             if (finished) {
               containerYPosition.value = initialPosition;
@@ -147,7 +139,7 @@ export const Popper = memo(
           }
         );
 
-        opacity.value = withSpring(0, controlledFadeSpringConfig);
+        opacity.value = withSpring(0, controlledFadeSpringConfig.current);
       }, [
         containerYPosition,
         controlledFadeSpringConfig,
@@ -171,18 +163,18 @@ export const Popper = memo(
           containerYPosition.value = initialPosition;
           opacity.value = 1;
 
-          // @TODO: to avoid unnecessary re-renders probably some of this values could use a ref
           if (params?.theme) {
             setControlledTheme(params.theme);
           }
           if (params?.direction) {
-            setControlledDirection(params.direction);
+            controlledDirection.current = params.direction;
           }
           if (params?.positionSpringConfig) {
-            setControlledPositionSpringConfig(params.positionSpringConfig);
+            controlledPositionSpringConfig.current =
+              params.positionSpringConfig;
           }
           if (params?.fadeSpringConfig) {
-            setControlledFadeSpringConfig(params.fadeSpringConfig);
+            controlledFadeSpringConfig.current = params.fadeSpringConfig;
           }
 
           // plays the animation again

--- a/src/contexts/FiestaContext.tsx
+++ b/src/contexts/FiestaContext.tsx
@@ -11,7 +11,7 @@ import {
   Stars as _Stars,
   EmojiPopper as _EmojiPopper,
   type PopperHandler,
-  type PopperProps,
+  type StartPopperParams,
 } from '../components';
 
 export enum FiestaAnimations {
@@ -22,8 +22,7 @@ export enum FiestaAnimations {
   Fireworks = 'Fireworks',
 }
 
-interface RunFiestaAnimationParams
-  extends Pick<PopperProps, 'theme' | 'direction'> {
+interface RunFiestaAnimationParams extends StartPopperParams {
   animation: FiestaAnimations;
 }
 

--- a/src/utils/confettis.ts
+++ b/src/utils/confettis.ts
@@ -7,3 +7,5 @@ export function randomIntFromInterval(min: number, max: number): number {
   // min and max included
   return Math.floor(Math.random() * (max - min + 1) + min);
 }
+
+export const DEFAULT_ANIMATION_DURATION = 6000;

--- a/src/utils/fireworks.ts
+++ b/src/utils/fireworks.ts
@@ -1,5 +1,10 @@
 import { screenWidth, screenHeight } from '../constants/dimensions';
 
+interface Coordinates {
+  x: number;
+  y: number;
+}
+
 export function fromRadians(angle: number) {
   return angle * (180.0 / Math.PI);
 }
@@ -8,9 +13,9 @@ export function generateRandomCoordinates(
   numElements: number,
   specificHeight?: number,
   specificWidth?: number
-): Array<{ x: number; y: number }> {
+): Array<Coordinates> {
   // Create an array to store the generated coordinates
-  const coordinates: Array<{ x: number; y: number }> = [];
+  const coordinates: Array<Coordinates> = [];
 
   // Generate random x,y coordinates until we have the desired number of elements
   while (coordinates.length < numElements) {


### PR DESCRIPTION
To allow more custom motions, the popper spring configs can be passed dynamically.

The new props work with both Fiesta context and direct render.

- `positionSpringConfig`
- `fadeSpringConfig`